### PR TITLE
Cache revocation fix

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -91,6 +91,7 @@ func GetValue(key string) []byte {
 	if ok {
 		item := value.(timedCacheItem)
 		item.UpdateRevokeTime()
+		item.Updating = false
 		cache.Set(item.Key, item)
 		return value.(timedCacheItem).Value
 	}

--- a/cache.go
+++ b/cache.go
@@ -65,7 +65,7 @@ func revoke() {
 	now := time.Now()
 	for _, value := range cache.Items() {
 		item := value.(timedCacheItem)
-		if now.After(item.RevokeTime) && !item.Updating {
+		if now.After(item.RevokeTime) {
 			log.Printf("Revoking item that has not been used in %v: %v", item.TTL, item.Key)
 			cache.Remove(item.Key)
 		}

--- a/cache.go
+++ b/cache.go
@@ -57,7 +57,7 @@ func Start() {
 }
 
 // Stop background tickers, close job channel, wait for workers to finish and empty cache
-func Stop() {
+func stop() {
 	log.Printf("Stop in-memory cache background processing")
 	refreshTicker.Stop()
 	revokeTicker.Stop()

--- a/cache.go
+++ b/cache.go
@@ -56,7 +56,7 @@ func Start() {
 	revokeTicker = doEvery(loopInterval, revoke)
 }
 
-// Stop background tickers
+// Stop background tickers, close job channel, wait for workers to finish and empty cache
 func Stop() {
 	log.Printf("Stop in-memory cache background processing")
 	refreshTicker.Stop()

--- a/cache.go
+++ b/cache.go
@@ -21,6 +21,9 @@ var cacheSize = 20
 // default ttl
 var ttl = 1 * time.Hour
 
+// revoke & refresh loop interval
+var loopInterval = 1 * time.Second
+
 var jobs chan timedCacheItem
 
 // StartWith background loading cache with specified parameters
@@ -40,8 +43,8 @@ func Start() {
 	for w := 1; w <= workerAmount; w++ {
 		go worker(w, jobs)
 	}
-	go doEvery(1*time.Second, refresh)
-	go doEvery(1*time.Second, revoke)
+	go doEvery(loopInterval, refresh)
+	go doEvery(loopInterval, revoke)
 }
 
 // check and update expiring items

--- a/cache_test.go
+++ b/cache_test.go
@@ -12,7 +12,7 @@ func TestRevoke(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
-		Stop()
+		stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
@@ -34,7 +34,7 @@ func TestTTLLessThanExpiration(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
-		Stop()
+		stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
@@ -54,7 +54,7 @@ func TestTTLLessThanExpiration(t *testing.T) {
 
 func TestGetValuePostponesRevoke(t *testing.T) {
 	StartWith(1, 1, 1, 1*time.Second)
-	defer Stop()
+	defer stop()
 	key := "TestGetValuePostponesRevoke"
 	i := CacheItem{
 		Key:        key,
@@ -85,7 +85,7 @@ func TestExpire(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
-		Stop()
+		stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
@@ -105,7 +105,7 @@ func TestExpire(t *testing.T) {
 
 func TestItemWithShortestTTLIsRevokedWhenCacheFillsUp(t *testing.T) {
 	StartWith(1, 11, 2, 1*time.Second)
-	defer Stop()
+	defer stop()
 	AddItem(CacheItem{
 		Key:        "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1",
 		Value:      []byte("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1"),
@@ -139,7 +139,7 @@ func TestConcurrentRefreshAndGetValueBug(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
-		Stop()
+		stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
@@ -169,7 +169,7 @@ func TestConcurrentRevokeAndGetValueBug(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
-		Stop()
+		stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond

--- a/cache_test.go
+++ b/cache_test.go
@@ -120,6 +120,7 @@ func TestConcurrentRefreshAndGetValueBug(t *testing.T) {
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
+	// Make sure revoke does not interfere here
 	StartWith(1, 11, 1, 5*time.Second)
 	// continuously spamming GetValue should manifest the bug
 	c := make(chan []byte, 1)
@@ -148,7 +149,7 @@ func TestConcurrentRevokeAndGetValueBug(t *testing.T) {
 	}()
 	loopInterval = 10 * time.Millisecond
 	StartWith(1, 11, 1, 20*time.Millisecond)
-	// Continuously spamming GetValue should force ConcurrentRefreshAndGetBug to manifest
+	// Continuously spamming GetValue should force ConcurrentRefreshAndGetBug to manifest if it is present
 	c := make(chan []byte, 1)
 	url := "https://httpbin.org/ip"
 	go busyGet(t, c, url)

--- a/cache_test.go
+++ b/cache_test.go
@@ -9,43 +9,58 @@ import (
 )
 
 func TestRevoke(t *testing.T) {
-	StartWith(1, 1, 1, 1*time.Second)
-	key := "xyzzy"
+	// Run refresh & revoke loops quicker than usual
+	defaultLoopInterval := loopInterval
+	defer func() {
+		Stop()
+		loopInterval = defaultLoopInterval
+	}()
+	loopInterval = 10 * time.Millisecond
+	StartWith(1, 1, 1, 15*time.Millisecond)
+	key := "TestRevoke"
 	i := CacheItem{
 		Key:        key,
-		Value:      []byte("foo"),
-		Expiration: 1 * time.Second,
+		Value:      []byte("TestRevoke"),
+		Expiration: 10 * time.Millisecond,
 		GetFunc:    noopGetFunc,
 	}
 	AddItem(i)
-	assert.True(t, string(GetValue(key)) == "foo")
-	time.Sleep(2000 * time.Millisecond)
+	assert.True(t, string(GetValue(key)) == "TestRevoke")
+	time.Sleep(25 * time.Millisecond)
 	assert.True(t, nil == GetValue(key), "Item should have been revoked by now")
 }
 
 func TestTTLLessThanExpiration(t *testing.T) {
-	StartWith(1, 1, 1, 1*time.Second)
-	key := "xyzzy"
+	// Run refresh & revoke loops quicker than usual
+	defaultLoopInterval := loopInterval
+	defer func() {
+		Stop()
+		loopInterval = defaultLoopInterval
+	}()
+	loopInterval = 10 * time.Millisecond
+	StartWith(1, 1, 1, 10*time.Millisecond)
+	key := "TestTTLLessThanExpiration"
 	i := CacheItem{
 		Key:        key,
-		Value:      []byte("foo"),
-		TTL:        1 * time.Second,
-		Expiration: 2 * time.Second,
+		Value:      []byte("TestTTLLessThanExpiration"),
+		TTL:        10 * time.Millisecond,
+		Expiration: 20 * time.Millisecond,
 		GetFunc:    noopGetFunc,
 	}
 	AddItem(i)
-	time.Sleep(1500 * time.Millisecond)
-	assert.True(t, string(GetValue(key)) == "foo", "Item should still be in cache")
+	time.Sleep(15 * time.Millisecond)
+	assert.True(t, string(GetValue(key)) == "TestTTLLessThanExpiration", "Item should still be in cache after the first revocation loop was run")
 }
 
 func TestGetValuePostponesRevoke(t *testing.T) {
 	StartWith(1, 1, 1, 1*time.Second)
-	key := "xyzzy"
+	defer Stop()
+	key := "TestGetValuePostponesRevoke"
 	i := CacheItem{
 		Key:        key,
-		Value:      []byte("foo"),
-		TTL:        1 * time.Second,
-		Expiration: 2 * time.Second,
+		Value:      []byte("TestGetValuePostponesRevoke"),
+		TTL:        10 * time.Millisecond,
+		Expiration: 10 * time.Millisecond,
 		GetFunc:    noopGetFunc,
 	}
 	now := time.Now()
@@ -56,60 +71,67 @@ func TestGetValuePostponesRevoke(t *testing.T) {
 	}
 	revokeAfterAdd := item.(timedCacheItem).RevokeTime
 	assert.True(t, now.Before(revokeAfterAdd))
-	time.Sleep(50 * time.Millisecond)
-	assert.True(t, string(GetValue(key)) == "foo", "Item should be in cache")
+	assert.True(t, string(GetValue(key)) == "TestGetValuePostponesRevoke", "Item should be in cache")
+	time.Sleep(5 * time.Millisecond)
 	item, ok = cache.Get(key)
 	if !ok {
-		t.Errorf("Should have got item %s from cache", key)
+		t.Errorf("Should have got item %s from cache after first GetValue", key)
 	}
 	revokeAfterGet := item.(timedCacheItem).RevokeTime
 	assert.True(t, revokeAfterAdd.Before(revokeAfterGet), "Revoke time should be postponed after GetValue: %v < %v", revokeAfterAdd, revokeAfterGet)
 }
 
 func TestExpire(t *testing.T) {
-	StartWith(1, 11, 1, 2*time.Second)
-	url := "https://httpbin.org/ip"
+	// Run refresh & revoke loops quicker than usual
+	defaultLoopInterval := loopInterval
+	defer func() {
+		Stop()
+		loopInterval = defaultLoopInterval
+	}()
+	loopInterval = 10 * time.Millisecond
+	StartWith(1, 11, 1, 1*time.Second)
+	key := "TestExpire"
 	value := randomGetFunc("")
 	i := CacheItem{
-		Key:        url,
+		Key:        key,
 		Value:      value,
-		Expiration: 1 * time.Second,
+		Expiration: 10 * time.Millisecond,
 		GetFunc:    randomGetFunc,
 	}
 	AddItem(i)
-	time.Sleep(2 * time.Second)
-	assert.NotEqual(t, string(value), string(GetValue(url)), "Item should have new value in cache")
+	time.Sleep(20 * time.Millisecond)
+	assert.NotEqual(t, string(value), string(GetValue(key)), "Item should have new value in cache")
 }
 
 func TestItemWithShortestTTLIsRevokedWhenCacheFillsUp(t *testing.T) {
 	StartWith(1, 11, 2, 1*time.Second)
+	defer Stop()
 	AddItem(CacheItem{
-		Key:        "1",
-		Value:      []byte("1"),
+		Key:        "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1",
+		Value:      []byte("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1"),
 		Expiration: 1 * time.Second,
 		TTL:        2 * time.Second,
 		GetFunc:    noopGetFunc,
 	})
 	AddItem(CacheItem{
-		Key:        "2",
-		Value:      []byte("2"),
+		Key:        "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp2",
+		Value:      []byte("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp2"),
 		Expiration: 1 * time.Second,
 		TTL:        1 * time.Second,
 		GetFunc:    noopGetFunc,
 	})
 	AddItem(CacheItem{
-		Key:        "3",
-		Value:      []byte("3"),
+		Key:        "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp3",
+		Value:      []byte("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp3"),
 		Expiration: 1 * time.Second,
 		TTL:        2 * time.Second,
 		GetFunc:    noopGetFunc,
 	})
 
-	assert.Equal(t, 2, cache.Count(), "Cache should have 2 items")
-	assert.Equal(t, "1", string(GetValue("1")))
-	assert.Equal(t, "3", string(GetValue("3")))
+	assert.Equal(t, "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1", string(GetValue("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp1")))
+	assert.Equal(t, "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp3", string(GetValue("TestItemWithShortestTTLIsRevokedWhenCacheFillsUp3")))
 	for k, _ := range cache.Items() {
-		assert.NotEqual(t, "2", k, "Item #2 should have been revoked when cache was full")
+		assert.NotEqual(t, "TestItemWithShortestTTLIsRevokedWhenCacheFillsUp2", k, "Item #2 should have been revoked when cache was full")
 	}
 }
 
@@ -117,6 +139,7 @@ func TestConcurrentRefreshAndGetValueBug(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
+		Stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
@@ -124,19 +147,20 @@ func TestConcurrentRefreshAndGetValueBug(t *testing.T) {
 	StartWith(1, 11, 1, 5*time.Second)
 	// continuously spamming GetValue should manifest the bug
 	c := make(chan []byte, 1)
-	url := "https://httpbin.org/ip"
-	go busyGet(t, c, url)
+	key := "TestConcurrentRefreshAndGetValueBug"
+	go busyGet(t, c, key)
 	value := randomGetFunc("")
 	i := CacheItem{
-		Key:        url,
+		Key:        key,
 		Value:      value,
 		Expiration: 10 * time.Millisecond,
 		GetFunc:    randomGetFunc,
 	}
 	AddItem(i)
-	time.Sleep(1 * time.Second)
+	// sleep long enough for the bug to kick in repeatably
+	time.Sleep(1013 * time.Millisecond)
 	c <- []byte("stop")
-	v, _ := cache.Get(url)
+	v, _ := cache.Get(key)
 	ci := v.(timedCacheItem)
 	assert.NotEqual(t, ci.Updating, true, "Item Should not be in updating state")
 }
@@ -145,26 +169,28 @@ func TestConcurrentRevokeAndGetValueBug(t *testing.T) {
 	// Run refresh & revoke loops quicker than usual
 	defaultLoopInterval := loopInterval
 	defer func() {
+		Stop()
 		loopInterval = defaultLoopInterval
 	}()
 	loopInterval = 10 * time.Millisecond
 	StartWith(1, 11, 1, 20*time.Millisecond)
 	// Continuously spamming GetValue should force ConcurrentRefreshAndGetBug to manifest if it is present
 	c := make(chan []byte, 1)
-	url := "https://httpbin.org/ip"
-	go busyGet(t, c, url)
+	key := "TestConcurrentRevokeAndGetValueBug"
+	go busyGet(t, c, key)
 	value := randomGetFunc("")
 	i := CacheItem{
-		Key:        url,
+		Key:        key,
 		Value:      value,
-		Expiration: 10 * time.Millisecond,
+		Expiration: 15 * time.Millisecond,
 		GetFunc:    randomGetFunc,
 	}
 	AddItem(i)
+	// sleep long enough for the bug to kick in repeatably
 	time.Sleep(1 * time.Second)
 	c <- []byte("stop")
-	time.Sleep(1 * time.Second)
-	assert.True(t, nil == GetValue(url), "Item should have been revoked by now")
+	time.Sleep(53 * time.Millisecond)
+	assert.True(t, nil == GetValue(key), "Item should have been revoked by now")
 }
 
 func noopGetFunc(s string) []byte {

--- a/util.go
+++ b/util.go
@@ -4,10 +4,14 @@ import (
 	"time"
 )
 
-func doEvery(d time.Duration, f func()) {
-	for range time.Tick(d) {
-		f()
-	}
+func doEvery(d time.Duration, f func()) *time.Ticker {
+	ticker := time.NewTicker(d)
+	go func() {
+		for range ticker.C {
+			f()
+		}
+	}()
+	return ticker
 }
 
 func max(d1 time.Duration, d2 time.Duration) time.Duration {


### PR DESCRIPTION
Make library mote thread-safe to prevent situation where items end up out of reach from refresh/revoke processes.

Tested running tests 100 times, tests passed every time (takes about 10 minutes :) )

go test -v -count=100